### PR TITLE
update from upstream

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ COPY src ./src
 RUN --mount=type=cache,id=full-build,target=/build/${APPLICATION_NAME}/target \
     cargo install --path . --target ${TARGET} --root /output
 
-FROM alpine:3.18.2@sha256:e13ce78057d83fcd976883c58b5169b0f60da578bd481d67532570eb75e4add5
+FROM alpine:3.18.2@sha256:c7431a7ecef19e2dbab2abd73b052da52de2d3bdce6b32757625a7497f4e93d3
 
 ARG APPLICATION_NAME
 


### PR DESCRIPTION
- chore(deps): update docker/build-push-action action to v4.1.0
- chore(deps): update actions/checkout action to v3.5.3
- chore(deps): update returntocorp/semgrep docker tag to v1.26.0
- chore(deps): update rust:1.70.0 docker digest to 508253a
- chore(deps): update docker/build-push-action action to v4.1.1
- chore(deps): update dependency semantic-release to ^21.0.5
- chore(deps): update docker/metadata-action action to v4.6.0
- chore(deps): update alpine docker tag to v3.18.2
- chore(deps): update returntocorp/semgrep docker tag to v1.27.0
- chore(deps): update docker/setup-buildx-action action to v2.7.0
- chore(deps): update github/codeql-action action to v2.20.0
- chore(deps): update alpine:3.18.2 docker digest to c7431a7
