### PR TITLE
update from upstream

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -308,12 +308,11 @@ jobs:
         run: |
           grcov $(find profiling -name "profile-*.profraw" -print) --source-dir . --binary-path ./target/debug/ --output-type lcov --branch --ignore-not-existing --llvm --keep-only "src/**" --keep-only "tests/**" --output-path ./reports/lcov.info
 
-      - name: Upload to CodeCov
-        uses: codecov/codecov-action@eaaf4bedf32dbdc6b720b63067d99c4d77d6047d # v3.1.4
+      - name: Upload to Coveralls
+        uses: coverallsapp/github-action@95b1a2355bd0e526ad2fd62da9fd386ad4c98474 # v2.2.1
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          directory: reports
-          fail_ci_if_error: true
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          path-to-lcov: reports/lcov.info
 
       - name: Fail if tests failed
         shell: bash

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -19,7 +19,7 @@
             "cwd": "${workspaceFolder}",
             "env": {
                 "RUST_BACKTRACE": "full",
-                "RUST_LOG": "jwt_decode=trace"
+                "RUST_LOG": "trace,jwt_decode=trace"
             }
         },
         {
@@ -42,7 +42,7 @@
             "cwd": "${workspaceFolder}",
             "env": {
                 "RUST_BACKTRACE": "full",
-                "RUST_LOG": "jwt_decode=trace"
+                "RUST_LOG": "trace,jwt_decode=trace"
             }
         }
     ]

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -18,7 +18,7 @@
         {
             "type": "cargo",
             "command": "build",
-            "args": [],
+            "args": ["--workspace", "--all-targets", "--all-features"],
             "problemMatcher": ["$rustc"],
             "group": "build",
             "label": "Rust: cargo build"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,12 +18,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
-name = "anyhow"
-version = "1.0.71"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c7d0618f0e0b7e8ff11427422b64564d5fb0be1940354bfe2e0529b18a9d9b8"
-
-[[package]]
 name = "backtrace"
 version = "0.3.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -135,7 +129,6 @@ checksum = "62b02a5381cc465bd3041d84623d0fa3b66738b52b8e2fc3bab8ad63ab032f4a"
 name = "jwt-decode"
 version = "0.0.0-development"
 dependencies = [
- "anyhow",
  "base64",
  "color-eyre",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,6 @@ repository = "https://github.com/kristof-mattei/jwt-decode"
 coverage = []
 
 [dependencies]
-anyhow = "1.0.71"
 base64 = "0.21.2"
 color-eyre = { version = "0.6.2", features = ["issue-url"] }
 serde_json = "1.0.102"

--- a/package-lock.json
+++ b/package-lock.json
@@ -83,9 +83,9 @@
       }
     },
     "node_modules/@actions/tool-cache/node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
       "bin": {
         "semver": "bin/semver.js"
@@ -1594,9 +1594,9 @@
       }
     },
     "node_modules/https-proxy-agent": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.0.tgz",
-      "integrity": "sha512-0euwPCRyAPSgGdzD1IVN9nJYHtBhJwb6XPfbpQcYbPCwrBidX6GzxmchnaF4sfF/jPb74Ojx5g4yTg3sixlyPw==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.1.tgz",
+      "integrity": "sha512-Eun8zV0kcYS1g19r78osiQLEFIRspRUDd9tIfBCTBPBeMieF/EsJNL8VI3xOIdYRDEkjQnqOYPsZ2DsWsVsFwQ==",
       "dev": true,
       "dependencies": {
         "agent-base": "^7.0.2",
@@ -2293,9 +2293,9 @@
       }
     },
     "node_modules/meow/node_modules/semver": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
       "dev": true,
       "bin": {
         "semver": "bin/semver"
@@ -6754,22 +6754,22 @@
       }
     },
     "node_modules/temp-dir": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-2.0.0.tgz",
-      "integrity": "sha512-aoBAniQmmwtcKp/7BzsH8Cxzv8OL736p7v1ihGb5e9DJ9kTwGWHrQrVB5+lfVDzfGrdRzXch+ig7LHaY1JTOrg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-3.0.0.tgz",
+      "integrity": "sha512-nHc6S/bwIilKHNRgK/3jlhDoIHcp45YgyiwcAk46Tr0LfEqGBVpmiAyuiuxeVE44m3mXnEeVhaipLOEWmH+Njw==",
       "dev": true,
       "engines": {
-        "node": ">=8"
+        "node": ">=14.16"
       }
     },
     "node_modules/tempy": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/tempy/-/tempy-3.0.0.tgz",
-      "integrity": "sha512-B2I9X7+o2wOaW4r/CWMkpOO9mdiTRCxXNgob6iGvPmfPWgH/KyUD6Uy5crtWBxIBe3YrNZKR2lSzv1JJKWD4vA==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tempy/-/tempy-3.1.0.tgz",
+      "integrity": "sha512-7jDLIdD2Zp0bDe5r3D2qtkd1QOCacylBuL7oa4udvN6v2pqr4+LcCr67C8DR1zkpaZ8XosF5m1yQSabKAW6f2g==",
       "dev": true,
       "dependencies": {
         "is-stream": "^3.0.0",
-        "temp-dir": "^2.0.0",
+        "temp-dir": "^3.0.0",
         "type-fest": "^2.12.2",
         "unique-string": "^3.0.0"
       },

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,7 +7,9 @@
 
 use base64::{engine::general_purpose, Engine};
 
-fn main() -> Result<(), anyhow::Error> {
+fn main() -> Result<(), color_eyre::Report> {
+    color_eyre::install()?;
+
     let arguments = std::env::args();
 
     let argument = if let Some(arg) = arguments.into_iter().nth(1) {
@@ -42,7 +44,7 @@ fn split_into_parts(jwt: &str) -> (&str, &str, &str) {
     )
 }
 
-fn decode(val: &str) -> Result<serde_json::Value, anyhow::Error> {
+fn decode(val: &str) -> Result<serde_json::Value, color_eyre::Report> {
     let decoded = general_purpose::URL_SAFE_NO_PAD.decode(val)?;
 
     let s = serde_json::from_slice::<serde_json::Value>(&decoded)?;
@@ -50,7 +52,7 @@ fn decode(val: &str) -> Result<serde_json::Value, anyhow::Error> {
     Ok(s)
 }
 
-fn pretty_print(value: &serde_json::Value) -> Result<(), anyhow::Error> {
+fn pretty_print(value: &serde_json::Value) -> Result<(), color_eyre::Report> {
     println!("{}", serde_json::to_string_pretty(value)?);
 
     Ok(())

--- a/update-name.sh
+++ b/update-name.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+
+NEW_NAME=$1
+
+FILTERED_NAME=$(echo "${NEW_NAME}" | sed -e "s/[a-z0-9-]//g")
+
+
+echo "New name = ${NEW_NAME}"
+
+
+if [[ ${#FILTERED_NAME} != 0 ]]; then
+    echo "Name only allows [a-z0-9-], found ${FILTERED_NAME} (length = ${#FILTERED_NAME})"
+    exit 1
+fi
+
+
+NEW_NAME_WITH_UNDERSCORE=$(echo "${NEW_NAME}" | sed -e "s/-/_/g")
+
+echo "New name with underscore = ${NEW_NAME_WITH_UNDERSCORE}"
+
+
+P1="rust-end-to-end-"
+OLD_NAME="${P1}application"
+OLD_NAME_WITH_UNDERSCORE=$(echo "${OLD_NAME}" | sed -e "s/-/_/g")
+
+echo ${OLD_NAME_WITH_UNDERSCORE}
+
+
+rg --hidden --files-with-matches ${OLD_NAME} | xargs -i sed -i "s/${OLD_NAME}/${NEW_NAME}/g" {}
+rg --hidden --files-with-matches ${OLD_NAME_WITH_UNDERSCORE}
+rg --hidden --files-with-matches ${OLD_NAME_WITH_UNDERSCORE} | xargs -i sed -i "s/${OLD_NAME_WITH_UNDERSCORE}/${NEW_NAME_WITH_UNDERSCORE}/g" {}


### PR DESCRIPTION
- chore(deps): update dependency conventional-changelog-conventionalcommits to ^6.1.0
- chore(deps): lock file maintenance
- chore(deps): update enricomi/publish-unit-test-result-action action to v2.8.0
- chore(deps): update node.js to >=v18.16.1
- chore(deps): update returntocorp/semgrep docker tag to v1.28.0
- chore(deps): update github/codeql-action action to v2.20.1
- chore(deps): update npm to >=9.7.2
- chore(deps): update dependency semver to ^7.5.3
- fix: build all with tests too
- fix: trace for all, not just the app
- fix: default is to use color-eyre
- fix: trace for run and test
- chore(deps): lock file maintenance
- chore(deps): update returntocorp/semgrep docker tag to v1.29.0
- chore(deps): update docker/setup-buildx-action action to v2.8.0
- chore(deps): update returntocorp/semgrep docker tag to v1.30.0
- chore(deps): update dependency semantic-release to ^21.0.6
- chore(deps): lock file maintenance
- chore(deps): update github/codeql-action action to v2.20.2
- chore(deps): update rust:1.70.0 docker digest to d3283ba
- chore(deps): update rust:1.70.0 docker digest to a8d4f44
- chore(deps): update rust:1.70.0 docker digest to 28ee882
- chore(deps): update dependency @semantic-release/release-notes-generator to ^11.0.4
- chore(deps): update dependency semantic-release to ^21.0.7
- chore(deps): update rust:1.70.0 docker digest to dbdf889
- chore(deps): update actions/setup-node action to v3.7.0
- chore(deps): update npm to >=9.8.0
- chore(deps): update github/codeql-action action to v2.20.3
- chore(deps): update dependency prettier to v3
- fix: add update-name script
- chore(deps): update mcr.microsoft.com/devcontainers/rust:1-1-bullseye docker digest to b732d41
- chore(deps): update docker/setup-buildx-action action to v2.9.0
- chore(deps): update returntocorp/semgrep docker tag to v1.31.1
- chore(deps): update dependency semver to ^7.5.4
- chore(deps): update returntocorp/semgrep docker tag to v1.31.2
- chore(deps): lock file maintenance
- chore(deps): update docker/setup-buildx-action action to v2.9.1
- fix: Coveralls as CodeCov keeps on failing
- fix: specify version, Renovate will pin it
- chore(deps): update github/codeql-action action to v2.20.4
- chore(deps): pin coverallsapp/github-action action to 95b1a23
- chore(deps): update rust to v1.71.0
- chore(deps): update returntocorp/semgrep docker tag to v1.32.0
- chore(deps): lock file maintenance
