### PR TITLE
update from upstream

### DIFF
--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -14,7 +14,7 @@ jobs:
     name: Prettier
     runs-on: ubuntu-latest
     steps:
-      - name: Check out repo
+      - name: Checkout
         uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
         with:
           show-progress: false

--- a/.github/workflows/retag-containers-after-release.yml
+++ b/.github/workflows/retag-containers-after-release.yml
@@ -42,7 +42,7 @@ jobs:
     if: |
       fromJSON(needs.repo-has-container.outputs.has_container) == true
     steps:
-      - name: Check out repo
+      - name: Checkout
         uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
         with:
           show-progress: false

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -22,29 +22,19 @@ jobs:
       image: returntocorp/semgrep:1.66.0@sha256:2fd35fa409f209e0fea0c2d72cf1e5b801a607959a93b13d04822bb3b6a9dfe4
 
     steps:
-      - name: Check out repo
+      - name: Checkout
         uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
         with:
           show-progress: false
 
       - name: Run semgrep
-        shell: bash
         env:
           SEMGREP_APP_TOKEN: ${{ secrets.SEMGREP_APP_TOKEN }}
         run: |
           semgrep ci --sarif --output=semgrep.sarif
 
-      - name: Fixup semgrep.sarif's startColumn==0 and/or endColumn==0
-        shell: bash
-        run: |
-          jq '.' semgrep.sarif > normalized.sarif
-          jq 'del(.runs[].results[].locations[].physicalLocation.region | select(.startColumn==0) | .startColumn)' normalized.sarif > fixed_start_column.sarif
-          jq 'del(.runs[].results[].locations[].physicalLocation.region | select(.endColumn==0) | .endColumn)' fixed_start_column.sarif > fixed_start_end_column.sarif
-
-          diff normalized.sarif fixed_start_end_column.sarif || true
-
       - name: Upload SARIF file for GitHub Advanced Security Dashboard
         if: always()
         uses: github/codeql-action/upload-sarif@1b1aada464948af03b950897e5eb522f92603cc2 # v3.24.9
         with:
-          sarif_file: fixed_start_end_column.sarif
+          sarif_file: semgrep.sarif

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,13 +1,14 @@
 {
-    "rust-analyzer.runnables.extraEnv": {
-        "RUST_LOG": "DEBUG,jwt_decode=TRACE"
-    },
-    "rust-analyzer.debug.openDebugPane": true,
+    "debug.internalConsoleOptions": "openOnSessionStart",
+    "prettier.configPath": "./.prettierrc.cjs",
     "rust-analyzer.debug.engineSettings": {
         "lldb": {
             "internalConsoleOptions": "openOnSessionStart",
             "terminal": "console"
         }
     },
-    "debug.internalConsoleOptions": "openOnSessionStart"
+    "rust-analyzer.debug.openDebugPane": true,
+    "rust-analyzer.runnables.extraEnv": {
+        "RUST_LOG": "DEBUG,jwt_decode=TRACE"
+    }
 }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,9 +19,9 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "backtrace"
-version = "0.3.69"
+version = "0.3.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2089b7e3f35b9dd2d0ed921ead4f6d318c27680d4a5bd167b3ee120edb105837"
+checksum = "26b05800d2e817c8b3b4b54abd461726265fa9789ae34330622f2db9ee696f9d"
 dependencies = [
  "addr2line",
  "cc",
@@ -266,9 +266,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.53"
+version = "2.0.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7383cd0e49fff4b6b90ca5670bfd3e9d6a733b3f90c686605aa7eec8c4996032"
+checksum = "002a1b3dbf967edfafc32655d0f377ab0bb7b994aa1d32c8cc7e9b8bf3ebb8f0"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/package-lock.json
+++ b/package-lock.json
@@ -82,13 +82,13 @@
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.23.5",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.23.5.tgz",
-      "integrity": "sha512-CgH3s1a96LipHCmSUmYFPwY7MNx8C3avkq7i4Wl3cfa662ldtUe4VM1TPXX70pfmrlWTb6jLqTYrZyT2ZTJBgA==",
+      "version": "7.24.2",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.24.2.tgz",
+      "integrity": "sha512-y5+tLQyV8pg3fsiln67BVLD1P13Eg4lh5RW9mF0zUuvLrv9uIQ4MCL+CRT+FTsBlBjcIan6PGsLcBN0m3ClUyQ==",
       "dev": true,
       "dependencies": {
-        "@babel/highlight": "^7.23.4",
-        "chalk": "^2.4.2"
+        "@babel/highlight": "^7.24.2",
+        "picocolors": "^1.0.0"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -104,14 +104,15 @@
       }
     },
     "node_modules/@babel/highlight": {
-      "version": "7.23.4",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.23.4.tgz",
-      "integrity": "sha512-acGdbYSfp2WheJoJm/EBBBLh/ID8KDc64ISZ9DYtBmC8/Q204PZJLHyzeB5qMzJ5trcOkybd78M4x2KWsUq++A==",
+      "version": "7.24.2",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.24.2.tgz",
+      "integrity": "sha512-Yac1ao4flkTxTteCDZLEvdxg2fZfz1v8M4QpaGypq/WPDqg3ijHYbDfs+LG5hvzSoqaSZ9/Z9lKSP3CjZjv+pA==",
       "dev": true,
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.22.20",
         "chalk": "^2.4.2",
-        "js-tokens": "^4.0.0"
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.0.0"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -696,24 +697,9 @@
       }
     },
     "node_modules/ansi-escapes": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-6.2.0.tgz",
-      "integrity": "sha512-kzRaCqXnpzWs+3z5ABPQiVke+iq0KXkHo8xiWV4RPTi5Yli0l97BEQuhXV1s7+aSU/fu1kUuxgS4MsQ0fRuygw==",
-      "dev": true,
-      "dependencies": {
-        "type-fest": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=14.16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/ansi-escapes/node_modules/type-fest": {
-      "version": "3.13.1",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-3.13.1.tgz",
-      "integrity": "sha512-tLq3bSNx+xSpwvAJnzrK0Ep5CLNWjvFTOp71URMaAEWBfRb9nnJiBoUe0tF8bI4ZFO3omgBR6NvnbzVUT3Ly4g==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-6.2.1.tgz",
+      "integrity": "sha512-4nJ3yixlEthEJ9Rk4vPcdBRkZvQZlYyu8j4/Mqz5sgIkddmEnH2Yj2ZrnP9S3tQOvSNRUIgVNF/1yPpRAGNRig==",
       "dev": true,
       "engines": {
         "node": ">=14.16"
@@ -962,9 +948,9 @@
       }
     },
     "node_modules/cli-table3": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.3.tgz",
-      "integrity": "sha512-w5Jac5SykAeZJKntOxJCrm63Eg5/4dhMWIcuTbo9rpE+brgaSZo0RuNJZeOyMgsUdhDeojvgyQLmjI+K50ZGyg==",
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.4.tgz",
+      "integrity": "sha512-Lm3L0p+/npIQWNIiyF/nAn7T5dnOwR3xNTHXYEBFBFVPXzCVNZ5lqEC/1eo/EVfpDsQ1I+TX4ORPQgp+UI0CRw==",
       "dev": true,
       "dependencies": {
         "string-width": "^4.2.0"
@@ -5324,6 +5310,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/picocolors": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
+      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
+      "dev": true
+    },
     "node_modules/picomatch": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
@@ -6132,9 +6124,9 @@
       }
     },
     "node_modules/type-fest": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.12.0.tgz",
-      "integrity": "sha512-5Y2/pp2wtJk8o08G0CMkuFPCO354FGwk/vbidxrdhRGZfd0tFnb4Qb8anp9XxXriwBgVPjdWbKpGl4J9lJY2jQ==",
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.14.0.tgz",
+      "integrity": "sha512-on5/Cw89wwqGZQu+yWO0gGMGu8VNxsaW9SB2HE8yJjllEk7IDTwnSN1dUVldYILhYPN5HzD7WAaw2cc/jBfn0Q==",
       "dev": true,
       "engines": {
         "node": ">=16"


### PR DESCRIPTION
- **chore(deps): update returntocorp/semgrep docker tag to v1.61.1**
- **chore(deps): update dorny/paths-filter action to v3.0.1**
- **chore(deps): update github/codeql-action action to v3.24.2**
- **chore(deps): update github/codeql-action action to v3.24.3**
- **chore(deps): update rust:1.76.0 docker digest to a71cd88**
- **chore: explicitely set prettierrc's path**
- **chore(deps): lock file maintenance**
- **chore(deps): update returntocorp/semgrep docker tag to v1.62.0**
- **chore(deps): update rui314/setup-mold digest to 910273f**
- **chore(deps): update github/codeql-action action to v3.24.5**
- **chore(deps): lock file maintenance**
- **chore(deps): update actions/download-artifact action to v4.1.3**
- **chore(deps): update docker/setup-buildx-action action to v3.1.0**
- **chore(deps): update enricomi/publish-unit-test-result-action action to v2.15.0**
- **chore(deps): update returntocorp/semgrep docker tag to v1.63.0**
- **chore: align title**
- **chore(deps): update enricomi/publish-unit-test-result-action action to v2.15.1**
- **chore(deps): update npm to >=10.5.0**
- **chore(deps): update github/codeql-action action to v3.24.6**
- **chore(deps): update actions/cache action to v4.0.1**
- **chore(deps): update rui314/setup-mold digest to c9803d2**
- **chore(deps): update actions/download-artifact action to v4.1.4**
- **chore(deps): update dorny/paths-filter action to v3.0.2**
- **chore(deps): lock file maintenance**
- **chore(deps): update mcr.microsoft.com/devcontainers/rust:1-1-bullseye docker digest to 77b7c17**
- **chore(deps): lock file maintenance**
- **chore(deps): update returntocorp/semgrep docker tag to v1.64.0**
- **chore(deps): update docker/build-push-action action to v5.2.0**
- **chore(deps): update rui314/setup-mold digest to 65ebd6e**
- **chore(deps): lock file maintenance**
- **chore(deps): update returntocorp/semgrep docker tag to v1.65.0**
- **chore(deps): update rust:1.76.0 docker digest to 969ca54**
- **chore(deps): update actions/checkout action to v4.1.2**
- **chore(deps): update rust:1.76.0 docker digest to 2d1630a**
- **chore(deps): update github/codeql-action action to v3.24.7**
- **chore(deps): update rust:1.76.0 docker digest to af1e799**
- **chore(deps): update rust:1.76.0 docker digest to d36f9d8**
- **chore(deps): update docker/login-action action to v3.1.0**
- **chore(deps): update docker/build-push-action action to v5.3.0**
- **chore(deps): update docker/setup-buildx-action action to v3.2.0**
- **fix(deps): update rust crate color-eyre to 0.6.3**
- **chore(deps): update dependency @semantic-release/github to v10**
- **chore(deps): update dependency semantic-release to v23.0.3**
- **chore(deps): update dependency semantic-release to v23.0.4**
- **chore(deps): lock file maintenance**
- **chore(deps): update dependency @semantic-release/commit-analyzer to v12**
- **chore(deps): update dependency semantic-release to v23.0.5**
- **chore(deps): update github/codeql-action action to v3.24.8**
- **chore(deps): update actions/cache action to v4.0.2**
- **chore(deps): update returntocorp/semgrep docker tag to v1.66.0**
- **chore(deps): update enricomi/publish-unit-test-result-action action to v2.16.0**
- **fix: don't set shell, not needed in semgrep container**
- **fix: separate scan and fixup, as the scan container doesn't have bash / jq anymore**
- **fix: only upload sarif file itself**
- **fix: set unpack folder, not filepath**
- **chore: checkout to satisfy the codeql tool**
- **chore(deps): update enricomi/publish-unit-test-result-action action to v2.16.1**
- **chore(deps): update rust to v1.77.0**
- **chore(deps): update github/codeql-action action to v3.24.9**
- **chore: rename semgrep job to make it register with semgrep**
- **chore: use semgrep action, not container**
- **chore(deps): update returntocorp/semgrep-action digest to 713efdd**
- **chore: back to container, the action is outdated**
- **chore: add category**
- **chore: semgrep 1 job**
- **chore: fix filename**
- **chore(deps): update rui314/setup-mold digest to 6bebc01**
