### PR TITLE
update from upstream

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -142,7 +142,7 @@ branches:
           - context: "codecov/project"
             app_id: 254
       # Required. Enforce all configured restrictions for administrators. Set to true to enforce required status checks for repository administrators. Set to null to disable.
-      enforce_admins: false
+      enforce_admins: null
       # Prevent merge commits from being pushed to matching branches
       required_linear_history: false
       # Required. Restrict who can push to this branch. Team and user restrictions are only available for organization-owned repositories. Set to null to disable.

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,13 +9,19 @@
             "request": "launch",
             "name": "Debug executable 'jwt-decode'",
             "cargo": {
-                "args": ["build", "--bin=jwt-decode", "--package=jwt-decode"],
+                "args": [
+                    "build",
+                    "--bin=jwt-decode",
+                    "--package=jwt-decode"
+                ],
                 "filter": {
                     "name": "jwt-decode",
                     "kind": "bin"
                 }
             },
-            "args": ["<PUT JWT HERE>"],
+            "args": [
+                "<PUT JWT HERE>"
+            ],
             "cwd": "${workspaceFolder}",
             "env": {
                 "RUST_BACKTRACE": "1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,10 +5,10 @@ version = "0.0.0-development"
 edition = "2021"
 rust-version = "1.79.0"
 authors = ["Kristof Mattei"]
-description = "Rust end-to-end application"
+description = "Rust seed application"
 license-file = "LICENSE"
-categories = ["starter", "end-to-end"]
-keywords = ["integrity", "end-to-end", "starter", "docker", "release"]
+categories = ["starter", "seed"]
+keywords = ["integrity", "seed", "starter", "docker", "release"]
 repository = "https://github.com/kristof-mattei/jwt-decode"
 
 [lints.clippy]

--- a/README.md
+++ b/README.md
@@ -1,16 +1,33 @@
-# Rust end-to-end application
+# jwt-decode
 
-It's written in Rust!
+Use:
 
-This is a framework for building Rust applications in combination with building Docker containers and never rebuilding code on release, instead we promote existing code.
+```
+echo "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c" | jwt-decode
+{
+  "alg": "HS256",
+  "typ": "JWT"
+}
+{
+  "iat": 1516239022,
+  "name": "John Doe",
+  "sub": "1234567890"
+}
+```
 
-## TODO and done
 
--   [x] Figure out how to deal with PRs pushing too many Docker containers<br />
-    > We only build containers on the tip of the PR, so even if you're pushing 10 commits, we'll only build one.
--   [ ] Remove old containers when the new one gets build for a PR?<br />
-        Or rely on a general weekly untagged cleanup?
--   [ ] Remove PR containers when PR closed<br />
-    > API currently unavailable
--   [x] How do we deal with older containers on `main`?<br />
-    > We move tags, so we'll need to wait for the API to clean up untagged versions
+If using via Docker:
+
+
+```
+echo "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c" | docker run -i jwt-decode
+{
+  "alg": "HS256",
+  "typ": "JWT"
+}
+{
+  "iat": 1516239022,
+  "name": "John Doe",
+  "sub": "1234567890"
+}
+```

--- a/update-name.sh
+++ b/update-name.sh
@@ -1,31 +1,25 @@
 #!/bin/bash
 
-
 NEW_NAME=$1
 
 FILTERED_NAME=$(echo "${NEW_NAME}" | sed -e "s/[a-z0-9-]//g")
 
-
 echo "New name = ${NEW_NAME}"
-
 
 if [[ ${#FILTERED_NAME} != 0 ]]; then
     echo "Name only allows [a-z0-9-], found ${FILTERED_NAME} (length = ${#FILTERED_NAME})"
     exit 1
 fi
 
-
 NEW_NAME_WITH_UNDERSCORE=$(echo "${NEW_NAME}" | sed -e "s/-/_/g")
 
 echo "New name with underscore = ${NEW_NAME_WITH_UNDERSCORE}"
 
-
-P1="rust-end-to-end-"
-OLD_NAME="${P1}application"
+PART_NAME="rust-"
+OLD_NAME="${PART_NAME}seed"
 OLD_NAME_WITH_UNDERSCORE=$(echo "${OLD_NAME}" | sed -e "s/-/_/g")
 
 echo ${OLD_NAME_WITH_UNDERSCORE}
-
 
 rg --hidden --files-with-matches ${OLD_NAME} | xargs -i sed -i "s/${OLD_NAME}/${NEW_NAME}/g" {}
 rg --hidden --files-with-matches ${OLD_NAME_WITH_UNDERSCORE}


### PR DESCRIPTION
- **chore(deps): update rust:1.79.0 docker digest to 2c454db**
- **chore(deps): update rui314/setup-mold digest to 65685f4**
- **chore(deps): lock file maintenance**
- **chore(deps): update returntocorp/semgrep docker tag to v1.76.0**
- **chore(deps): update docker/build-push-action action to v6**
- **chore(deps): update docker/build-push-action digest to 94f8f8c**
- **chore(deps): update docker/build-push-action action to v6.0.1**
- **chore(deps): update docker/build-push-action action to v6.0.2**
- **chore(deps): update dependency node to v20.15.0**
- **chore(deps): update alpine docker tag to v3.20.1**
- **chore(deps): update docker/build-push-action action to v6.1.0**
- **chore(deps): update dependency @semantic-release/release-notes-generator to v14.0.1**
- **chore: change name**
- **chore(deps): lock file maintenance**
- **chore: separate the name so the rename script doesn't update it**
- **chore(deps): lock file maintenance**
- **chore(deps): update returntocorp/semgrep docker tag to v1.77.0**
- **chore(deps): update docker/build-push-action action to v6.2.0**
- **chore(deps): update returntocorp/semgrep docker tag to v1.78.0**
- **chore(deps): update github/codeql-action action to v3.25.11**
- **chore(deps): lock file maintenance**
- **chore(deps): update dependency @semantic-release/github to v10.0.7**
- **chore(deps): update rust:1.79.0 docker digest to 4c4f16b**
- **chore(deps): update rust:1.79.0 docker digest to 4c45f61**
- **chore(deps): update docker/build-push-action action to v6.3.0**
- **chore: enforce_admins should be null if you want to disable it...**
- **chore(deps): update docker/setup-buildx-action action to v3.4.0**
