### PR TITLE
debian gcc

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,1 @@
-[target.aarch64-unknown-linux-musl]
-linker = "aarch64-linux-gnu-gcc"
+

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -296,10 +296,10 @@ jobs:
 
           cargo --version
 
-      - name: Install llvm-tools-preview
+      - name: Install llvm-tools
         shell: bash
         run: |
-          rustup component add llvm-tools-preview
+          rustup component add llvm-tools
 
           # restore symlinks
           rustup update

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -152,9 +152,9 @@ checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "owo-colors"
-version = "4.2.0"
+version = "4.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1036865bb9422d3300cf723f657c2851d0e9ab12567854b1f4eba3d77decf564"
+checksum = "26995317201fa17f3656c36716aed4a7c81743a9634ac4c99c0eeda495db0cec"
 
 [[package]]
 name = "pin-project-lite"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,10 @@ perf = "warn"
 style = "warn"
 suspicious = "warn"
 
+# this has 0 performance implications, the binding is compiled away, and it could cause issues
+# when done blindly, plus it makes it harder to debug as you cannot put breakpoints on return
+# values of functions (yet)
+let_and_return = { level = "allow", priority = 127 }
 # this one is debatable. continue is used in places to be explicit, and to guard against
 # issues when refactoring
 needless_continue = { level = "allow", priority = 127 }
@@ -39,7 +43,3 @@ non_ascii_idents = { level = "deny", priority = 127 }
 base64 = "0.22.1"
 color-eyre = "0.6.4"
 serde_json = "1.0.140"
-
-# OpenSSL for musl
-# [target.'cfg(all(any(target_arch="x86_64", target_arch="aarch64"), target_os="linux", target_env="musl"))'.dependencies]
-# openssl = { version = "0.10.36", features = ["vendored"] }

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,8 @@ RUN rm -f /etc/apt/apt.conf.d/docker-clean \
 
 # borrowed (Ba Dum Tss!) from
 # https://github.com/pablodeymo/rust-musl-builder/blob/7a7ea3e909b1ef00c177d9eeac32d8c9d7d6a08c/Dockerfile#L48-L49
-RUN --mount=type=cache,id=apt-cache-amd64,target=/var/cache/apt,sharing=locked \
-    --mount=type=cache,id=apt-lib-amd64,target=/var/lib/apt,sharing=locked \
+RUN --mount=type=cache,id=apt-cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,id=apt-lib,target=/var/lib/apt,sharing=locked \
     apt-get update \
     && apt-get --no-install-recommends install --yes \
         build-essential \
@@ -20,17 +20,20 @@ ARG TARGET=x86_64-unknown-linux-musl
 
 FROM rust-base AS rust-linux-arm64
 ARG TARGET=aarch64-unknown-linux-musl
-RUN --mount=type=cache,id=apt-cache-arm64,from=rust-base,source=/var/cache/apt,target=/var/cache/apt,sharing=locked \
-    --mount=type=cache,id=apt-lib-arm64,from=rust-base,source=/var/lib/apt,target=/var/lib/apt,sharing=locked \
-    dpkg --add-architecture arm64 \
-    && apt-get update \
-    && apt-get --no-install-recommends install --yes \
-        libc6-dev-arm64-cross \
-        gcc-aarch64-linux-gnu
 
 FROM rust-${TARGETPLATFORM//\//-} AS rust-cargo-build
 
-RUN rustup target add ${TARGET} && rustup component add clippy rustfmt
+# expose (used in ./build.sh)
+ARG BUILDPLATFORM
+ARG TARGETPLATFORM
+ARG TARGETARCH
+
+COPY ./setup-env.sh .
+RUN --mount=type=cache,id=apt-cache,from=rust-base,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,id=apt-lib,from=rust-base,target=/var/lib/apt,sharing=locked \
+    ./setup-env.sh
+
+RUN rustup target add ${TARGET}
 
 # The following block
 # creates an empty app, and we copy in Cargo.toml and Cargo.lock as they represent our dependencies
@@ -38,16 +41,25 @@ RUN rustup target add ${TARGET} && rustup component add clippy rustfmt
 # That means that if our dependencies don't change rebuilding is much faster
 WORKDIR /build
 RUN cargo new ${APPLICATION_NAME}
+
 WORKDIR /build/${APPLICATION_NAME}
+
+COPY ./build.sh .
+
 COPY .cargo ./.cargo
 COPY Cargo.toml Cargo.lock ./
 
 RUN --mount=type=cache,target=/build/${APPLICATION_NAME}/target \
     --mount=type=cache,id=cargo-git,target=/usr/local/cargo/git/db,sharing=locked \
     --mount=type=cache,id=cargo-registery,target=/usr/local/cargo/registry/,sharing=locked \
-    cargo build --release --target ${TARGET}
+    ./build.sh build --release --target ${TARGET}
 
 FROM rust-cargo-build AS rust-build
+
+# expose (used in ./build.sh)
+ARG BUILDPLATFORM
+ARG TARGETPLATFORM
+ARG TARGETARCH
 
 WORKDIR /build/${APPLICATION_NAME}
 
@@ -61,9 +73,9 @@ RUN touch ./src/main.rs
 RUN --mount=type=cache,target=/build/${APPLICATION_NAME}/target \
     --mount=type=cache,id=cargo-git,target=/usr/local/cargo/git/db,sharing=locked \
     --mount=type=cache,id=cargo-registery,target=/usr/local/cargo/registry/,sharing=locked \
-    cargo install --path . --target ${TARGET} --root /output
+    ./build.sh install --path . --target ${TARGET} --root /output
 
-FROM alpine:3.21.3@sha256:a8560b36e8b8210634f77d9f7f9efd7ffa463e380b75e2e74aff4511df3ef88c AS passwd-build
+FROM --platform=${BUILDPLATFORM} alpine:3.21.3@sha256:a8560b36e8b8210634f77d9f7f9efd7ffa463e380b75e2e74aff4511df3ef88c AS passwd-build
 
 # setting `--system` prevents prompting for a password
 RUN addgroup --gid 900 appgroup \

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+# sane defaults
+compiler="gcc"
+# static linking
+flags="-Clink-self-contained=yes -Clinker=rust-lld"
+
+# mind the space between the [ and "
+if [[ "$BUILDPLATFORM" != "$TARGETPLATFORM" ]]; then
+    case $TARGET in
+        x86_64-unknown-linux-musl)
+            compiler="i686-linux-gnu-gcc"
+            ;;
+        aarch64-unknown-linux-musl)
+            compiler="aarch64-linux-gnu-gcc"
+            ;;
+        *)
+            echo "INVALID CONFIGURATION"
+            exit 1
+            ;;
+    esac
+fi
+
+# replace - with _ in the Rust target
+target_lower=${TARGET//-/_}
+cc_var=CC_${target_lower}
+declare -x "${cc_var}=${compiler}"
+
+RUSTFLAGS=$flags cargo $@

--- a/setup-env.sh
+++ b/setup-env.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+dpkg_add_arch() {
+    dpkg --add-architecture $1
+    apt-get update
+    apt-get --no-install-recommends install --yes \
+        gcc-$2-linux-gnu
+}
+
+# mind the space between the [ and "
+if [[ "$BUILDPLATFORM" != "$TARGETPLATFORM" ]]; then
+    case $TARGET in
+        x86_64-unknown-linux-musl)
+            dpkg_add_arch "amd64" "i686"
+
+            apt-get --no-install-recommends install --yes \
+                gcc-12-multilib-i686-linux-gnu
+            ;;
+        aarch64-unknown-linux-musl)
+            dpkg_add_arch "arm64" "aarch64"
+            ;;
+        *)
+            echo "INVALID CONFIGURATION"
+            exit 1
+            ;;
+    esac
+fi
+


### PR DESCRIPTION
- **chore(deps): update rust:1.86.0 docker digest to c42032c**
- **chore(deps): update rust:1.86.0 docker digest to a2ccb7c**
- **chore(deps): update rust:1.86.0 docker digest to 300ec56**
- **chore(deps): update mcr.microsoft.com/devcontainers/rust:1-1-bullseye docker digest to d9c118e**
- **chore(deps): update returntocorp/semgrep docker tag to v1.121.0**
- **chore(deps): update dependency prettier-plugin-sh to v0.17.3**
- **chore(deps): update dependency prettier-plugin-sh to v0.17.4**
- **chore(deps): lock file maintenance**
- **chore(deps): update returntocorp/semgrep docker tag to v1.122.0**
- **chore(deps): update node.js to v22.15.1**
- **chore(deps): update docker/build-push-action action to v6.17.0**
- **chore(deps): update rust docker tag to v1.87.0**
- **chore(deps): update rust to v1.87.0**
- **chore(deps): update codecov/codecov-action action to v5.4.3**
- **chore(deps): update rust:1.87.0 docker digest to 5e33ae7**
- **chore(deps): update npm to >=11.4.0**
- **chore(deps): update github/codeql-action action to v3.28.18**
- **fix: disable clippy 1.87.0 let_and_return**
- **chore: change wording**
- **feat: switch to alpine**
- **feat: use script to set up cargo env and then build**
- **fix: use bash for dynamic variables**
- **feat: better multi-platform**
- **feat: multi-platform working!**
- **feat: setup-env now is cached as well**
- **fix: gcc-12-multilib-$arch-linux-gnu is only for i686**
