### PR TITLE
update from upstream

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,11 @@ keywords = ["cli", "JWT", "Docker"]
 repository = "https://github.com/kristof-mattei/jwt-decode"
 include = ["src/**", "/LICENSE", "/LICENSE-*"]
 
+[dependencies]
+base64 = "0.22.1"
+color-eyre = "0.6.5"
+serde_json = "1.0.141"
+
 [lints.clippy]
 # don't stop from compiling / running
 all = "warn"
@@ -176,8 +181,3 @@ uninlined-format-args = { level = "allow", priority = 127 }
 [lints.rust]
 let_underscore_drop = { level = "deny", priority = 127 }
 non_ascii_idents = { level = "deny", priority = 127 }
-
-[dependencies]
-base64 = "0.22.1"
-color-eyre = "0.6.5"
-serde_json = "1.0.141"


### PR DESCRIPTION
- **fix: we know that sort order when iterating over hash-type isn't guaranteed**
- **chore: move deps, disable as_conversions, too broad**
