### PR TITLE
update from upstream

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,18 +5,13 @@
     "version": "0.2.0",
     "configurations": [
         {
+            "name": "Debug executable 'jwt-decode'",
             "type": "lldb",
             "request": "launch",
-            "name": "Debug executable 'jwt-decode'",
             "cargo": {
-                "args": ["build", "--bin=jwt-decode", "--package=jwt-decode"],
-                "filter": {
-                    "name": "jwt-decode",
-                    "kind": "bin"
-                }
+                "args": ["run", "--bin=jwt-decode"]
             },
             "args": ["<PUT JWT HERE>"],
-            "cwd": "${workspaceFolder}",
             "env": {
                 "RUST_BACKTRACE": "1",
                 "RUST_LOG": "DEBUG,jwt_decode=TRACE"
@@ -25,23 +20,12 @@
             "terminal": "integrated"
         },
         {
-            "type": "lldb",
-            "request": "launch",
             "name": "Debug unit tests in executable 'jwt-decode'",
+            "type": "lldb",
+            "request": "launch",
             "cargo": {
-                "args": [
-                    "test",
-                    "--no-run",
-                    "--bin=jwt-decode",
-                    "--package=jwt-decode"
-                ],
-                "filter": {
-                    "name": "jwt-decode",
-                    "kind": "bin"
-                }
+                "args": ["test", "--bin=jwt-decode"]
             },
-            "args": [],
-            "cwd": "${workspaceFolder}",
             "env": {
                 "RUST_BACKTRACE": "1",
                 "RUST_LOG": "DEBUG,jwt_decode=TRACE"
@@ -50,23 +34,12 @@
             "terminal": "integrated"
         },
         {
+            "name": "Debug integration test 'integration_tests'",
             "type": "lldb",
             "request": "launch",
-            "name": "Debug integration test 'integration_tests'",
             "cargo": {
-                "args": [
-                    "test",
-                    "--no-run",
-                    "--test=integration_tests",
-                    "--package=jwt-decode"
-                ],
-                "filter": {
-                    "name": "integration_tests",
-                    "kind": "test"
-                }
+                "args": ["test", "--test=integration_tests"]
             },
-            "args": [],
-            "cwd": "${workspaceFolder}",
             "env": {
                 "RUST_BACKTRACE": "1",
                 "RUST_LOG": "DEBUG,jwt_decode=TRACE"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ categories = ["command-line-utilities"]
 keywords = ["cli", "JWT", "Docker"]
 repository = "https://github.com/kristof-mattei/jwt-decode"
 include = ["src/**", "/LICENSE", "/LICENSE-*"]
+build = "src/build.rs"
 
 [dependencies]
 base64 = "0.22.1"
@@ -29,23 +30,16 @@ style = "warn"
 suspicious = "warn"
 
 # restriction
-
+absolute_paths = { level = "deny", priority = 127 }
 # Lib only
 # alloc_instead_of_core = { level = "deny", priority = 127 }
-# std_instead_of_alloc = { level = "deny", priority = 127 }
-# std_instead_of_core = { level = "deny", priority = 127 }
-# exhaustive_enums = { level = "deny", priority = 127 }
-# exhaustive_structs = { level = "deny", priority = 127 }
-# empty_enum_variants_with_brackets = { level = "deny", priority = 127 }
-# empty_structs_with_brackets = { level = "deny", priority = 127 }
-# missing_inline_in_public_items = { level = "deny", priority = 127 }
-
-absolute_paths = { level = "deny", priority = 127 }
 allow_attributes = { level = "deny", priority = 127 }
 allow_attributes_without_reason = { level = "deny", priority = 127 }
+# No
+# arbitrary_source_item_ordering = { level = "deny", priority = 127 }
 # Debatable
 # arithmetic_side_effects = { level = "deny", priority = 127 }
-# Debatable
+# Debatable, the ones below deny more specific occurences
 # as_conversions = { level = "deny", priority = 127 }
 as_pointer_underscore = { level = "deny", priority = 127 }
 as_underscore = { level = "deny", priority = 127 }
@@ -54,38 +48,57 @@ big_endian_bytes = { level = "deny", priority = 127 }
 cfg_not_test = { level = "deny", priority = 127 }
 # ensure we do Arc::clone(&arc) instead of arc.clone()
 clone_on_ref_ptr = { level = "deny", priority = 127 }
+# No
+# cognitive_complexity = { level = "deny", priority = 127 }
 create_dir = { level = "deny", priority = 127 }
 dbg_macro = { level = "deny", priority = 127 }
 decimal_literal_representation = { level = "deny", priority = 127 }
-# Debatable
+# No, false positives / false negatives
 # default_numeric_fallback = { level = "deny", priority = 127 }
 default_union_representation = { level = "deny", priority = 127 }
 deref_by_slicing = { level = "deny", priority = 127 }
+# No, we already have `non_ascii_idents` which is even bette
+# disallowed_script_idents = { level = "deny", priority = 127 }
 doc_include_without_cfg = { level = "deny", priority = 127 }
 else_if_without_else = { level = "deny", priority = 127 }
 empty_drop = { level = "deny", priority = 127 }
+# Lib only
+# empty_enum_variants_with_brackets = { level = "deny", priority = 127 }
+# Lib only
+# empty_structs_with_brackets = { level = "deny", priority = 127 }
 error_impl_error = { level = "deny", priority = 127 }
+# Lib only
+# exhaustive_enums = { level = "deny", priority = 127 }
+# Lib only
+# exhaustive_structs = { level = "deny", priority = 127 }
 exit = { level = "deny", priority = 127 }
+# No, unwrap (or expect) is information to the reader
+# expect_used = { level = "deny", priority = 127 }
 field_scoped_visibility_modifiers = { level = "deny", priority = 127 }
 filetype_is_file = { level = "deny", priority = 127 }
 # Debatable
 # float_arithmetic = { level = "deny", priority = 127 }
 float_cmp_const = { level = "deny", priority = 127 }
 fn_to_numeric_cast_any = { level = "deny", priority = 127 }
-# Debatable
+# No, `.get().unwrap()` is more explicit than []. This is not about `.get().expect()`
 # get_unwrap = { level = "deny", priority = 127 }
 host_endian_bytes = { level = "deny", priority = 127 }
 # Debatable
 # if_then_some_else_none = { level = "deny", priority = 127 }
 impl_trait_in_params = { level = "deny", priority = 127 }
-# Debatable
+# We want implicit return
+# implicit_return = { level = "deny", priority = 127 }
+# Debatable, but probably should be turned on in the future
 # indexing_slicing = { level = "deny", priority = 127 }
 infinite_loop = { level = "deny", priority = 127 }
 inline_asm_x86_att_syntax = { level = "deny", priority = 127 }
+# We want intel
+# inline_asm_x86_intel_syntax = { level = "deny", priority = 127 }
 # Debatable
 # integer_division = { level = "deny", priority = 127 }
 # Debatable
 # integer_division_remainder_used = { level = "deny", priority = 127 }
+iter_over_hash_type = { level = "deny", priority = 127 }
 large_include_file = { level = "deny", priority = 127 }
 let_underscore_must_use = { level = "deny", priority = 127 }
 let_underscore_untyped = { level = "deny", priority = 127 }
@@ -94,7 +107,18 @@ lossy_float_literal = { level = "deny", priority = 127 }
 # Debatable
 # map_err_ignore = { level = "deny", priority = 127 }
 map_with_unused_argument_over_ranges = { level = "deny", priority = 127 }
+mem_forget = { level = "deny", priority = 127 }
+# Debatable
+# min_ident_chars = { level = "deny", priority = 127 }
 missing_assert_message = { level = "deny", priority = 127 }
+# Debatable
+# missing_asserts_for_indexing = { level = "deny", priority = 127 }
+# No
+# missing_docs_in_private_items = { level = "deny", priority = 127 }
+# Lib only
+# missing_inline_in_public_items = { level = "deny", priority = 127 }
+# No
+# missing_trait_methods = { level = "deny", priority = 127 }
 mixed_read_write_in_expression = { level = "deny", priority = 127 }
 mod_module_files = { level = "deny", priority = 127 }
 # Debatable
@@ -107,37 +131,64 @@ mutex_integer = { level = "deny", priority = 127 }
 needless_raw_strings = { level = "deny", priority = 127 }
 non_ascii_literal = { level = "deny", priority = 127 }
 non_zero_suggestions = { level = "deny", priority = 127 }
+# No
+# panic = { level = "deny", priority = 127 }
 panic_in_result_fn = { level = "deny", priority = 127 }
-# Debatable
-# partial_pub_fields = { level = "deny", priority = 127 }
+partial_pub_fields = { level = "deny", priority = 127 }
+# No, `.join()` does `.clone()`
+# pathbuf_init_then_push = { level = "deny", priority = 127 }
 pattern_type_mismatch = { level = "deny", priority = 127 }
+# No
+# pointer_format = { level = "deny", priority = 127 }
 precedence_bits = { level = "deny", priority = 127 }
 # Debatable
 # print_stderr = { level = "deny", priority = 127 }
 # Debatable
 # print_stdout = { level = "deny", priority = 127 }
+# Disable in libs
+pub_use = { level = "deny", priority = 127 }
+# No, we want the shorthand
+# pub_with_shorthand = { level = "deny", priority = 127 }
 pub_without_shorthand = { level = "deny", priority = 127 }
+# No
+# question_mark_used = { level = "deny", priority = 127 }
 rc_buffer = { level = "deny", priority = 127 }
 rc_mutex = { level = "deny", priority = 127 }
 redundant_test_prefix = { level = "deny", priority = 127 }
+# No, explicitness trumps brevity
+# redundant_type_annotations = { level = "deny", priority = 127 }
+# No, explicitness
+# ref_patterns = { level = "deny", priority = 127 }
 renamed_function_params = { level = "deny", priority = 127 }
 rest_pat_in_fully_bound_structs = { level = "deny", priority = 127 }
 return_and_then = { level = "deny", priority = 127 }
-# Debatable, need to think about it
+# Debatable, but probably should be turned on in the future
 # same_name_method = { level = "deny", priority = 127 }
+# No, we don't want `mod.rs`
+# self_named_module_files = { level = "deny", priority = 127 }
 semicolon_inside_block = { level = "deny", priority = 127 }
+# No, we want them outside, not inside
+# semicolon_outside_block = { level = "deny", priority = 127 }
+# No, we want them to be separated by `_`
+# separated_literal_suffix = { level = "deny", priority = 127 }
 # Debatable
 # shadow_reuse = { level = "deny", priority = 127 }
 # Debatable
 # shadow_same = { level = "deny", priority = 127 }
 # Debatable
 # shadow_unrelated = { level = "deny", priority = 127 }
+# No, clarity is important, also, this helps against binary bloat when doing monomorphization
+# single_call_fn = { level = "deny", priority = 127 }
+# No
+# single_char_lifetime_names = { level = "deny", priority = 127 }
+# Lib only
+# std_instead_of_alloc = { level = "deny", priority = 127 }
+# Lib only
+# std_instead_of_core = { level = "deny", priority = 127 }
 str_to_string = { level = "deny", priority = 127 }
 string_add = { level = "deny", priority = 127 }
 string_lit_chars_any = { level = "deny", priority = 127 }
-# Debatable, but no
-# string_slice = { level = "deny", priority = 127 }
-string_to_string = { level = "deny", priority = 127 }
+string_slice = { level = "deny", priority = 127 }
 suspicious_xor_used_as_pow = { level = "deny", priority = 127 }
 tests_outside_test_module = { level = "deny", priority = 127 }
 todo = { level = "deny", priority = 127 }
@@ -148,9 +199,17 @@ unnecessary_safety_comment = { level = "deny", priority = 127 }
 unnecessary_safety_doc = { level = "deny", priority = 127 }
 unnecessary_self_imports = { level = "deny", priority = 127 }
 unneeded_field_pattern = { level = "deny", priority = 127 }
+# No, this is information for the reader and compiler
+# unreachable = { level = "deny", priority = 127 }
 unseparated_literal_suffix = { level = "deny", priority = 127 }
 unused_result_ok = { level = "deny", priority = 127 }
 unused_trait_names = { level = "deny", priority = 127 }
+# No, unwrap (or expect) is information to the reader
+# unwrap_in_result = { level = "deny", priority = 127 }
+# No, unwrap (or expect) is information to the reader
+# unwrap_used = { level = "deny", priority = 127 }
+# No, we know that we shouldn't test on debug formats
+# use_debug  = { level = "deny", priority = 127 }
 verbose_file_reads = { level = "deny", priority = 127 }
 wildcard_enum_match_arm = { level = "deny", priority = 127 }
 
@@ -177,7 +236,7 @@ redundant_else = { level = "allow", priority = 127 }
 # this one causes confusion when combining variables (`foo`) and
 # dereferenced variables (`foo.bar`). The latter cannot be inlined
 # so we don't inline anything
-uninlined-format-args = { level = "allow", priority = 127 }
+uninlined_format_args = { level = "allow", priority = 127 }
 
 [lints.rust]
 let_underscore_drop = { level = "deny", priority = 127 }

--- a/build-all.sh
+++ b/build-all.sh
@@ -4,17 +4,13 @@ set -e
 build() {
     APPLICATION_NAME=$1
     PLATFORM=$2
-    docker build \
+    docker buildx \
+        build \
         --file Dockerfile . \
-        --tag $APPLICATION_NAME:latest-${2//\//-} \
+        --tag $APPLICATION_NAME:latest \
         --build-arg APPLICATION_NAME=$APPLICATION_NAME \
         --platform $PLATFORM \
         --progress=plain
 }
 
-name=$(basename ${PWD})
-
-build $name linux/amd64/v3
-build $name linux/amd64/v2
-build $name linux/amd64
-build $name linux/arm64
+build $(basename ${PWD}) linux/amd64/v3,linux/amd64/v2,linux/amd64,linux/arm64

--- a/build-scripts/build.sh
+++ b/build-scripts/build.sh
@@ -25,7 +25,7 @@ case $TARGET in
         ;;
 esac
 
-rust_flags="-Clink-self-contained=yes -Clinker=rust-lld ${target_cpu}"
+rustflags="-Clink-self-contained=yes -Clinker=rust-lld ${target_cpu}"
 
 # replace - with _ in the Rust target
 target_lower=${TARGET//-/_}
@@ -41,4 +41,4 @@ declare -x "${cxx_var}=${cpp_compiler}"
 cargo_target_linker_var=CARGO_TARGET_${target_upper}_LINKER
 declare -x "${cargo_target_linker_var}=${c_compiler}"
 
-RUSTFLAGS=$rust_flags cargo $@
+RUSTFLAGS=$rustflags cargo $@ --target ${TARGET}

--- a/src/build.rs
+++ b/src/build.rs
@@ -1,0 +1,46 @@
+use std::env;
+use std::ffi::OsStr;
+
+fn main() {
+    export_var(
+        "COMPILE_TIME_HOST",
+        &env::var("HOST").expect("HOST is set for build scripts"),
+    );
+    export_var(
+        "COMPILE_TIME_TARGET",
+        &env::var("TARGET").expect("TARGET is set for build scripts"),
+    );
+    export_var(
+        "COMPILE_TIME_TARGET_CPU",
+        &extract_target_cpu_from_rustflags(
+            &env::var_os("CARGO_ENCODED_RUSTFLAGS").unwrap_or_default(),
+        )
+        .unwrap_or_default(),
+    );
+
+    println!("cargo:rerun-if-changed-env=HOST");
+    println!("cargo:rerun-if-changed-env=TARGET");
+    println!("cargo:rerun-if-changed-env=CARGO_ENCODED_RUSTFLAGS");
+}
+
+fn extract_target_cpu_from_rustflags(rustflags: &OsStr) -> Option<String> {
+    const ASCII_SEPARATOR: char = '\x1f';
+
+    let rustflags = rustflags.to_string_lossy();
+
+    let mut cpu = None;
+
+    for flag in rustflags.split(ASCII_SEPARATOR) {
+        let stripped_c = flag.strip_prefix("-C").unwrap_or(flag);
+
+        if let Some(target_cpu) = stripped_c.strip_prefix("target-cpu=") {
+            cpu = Some(target_cpu);
+        }
+    }
+
+    cpu.map(str::to_owned)
+}
+
+fn export_var(name: &str, value: &str) {
+    println!("cargo:rustc-env={}={}", name, value);
+}

--- a/src/build_env.rs
+++ b/src/build_env.rs
@@ -1,0 +1,48 @@
+pub const COMPILE_TIME_HOST: &str = env!("COMPILE_TIME_HOST");
+pub const COMPILE_TIME_TARGET: &str = env!("COMPILE_TIME_TARGET");
+pub const COMPILE_TIME_TARGET_CPU: Option<&str> = const {
+    let cttc = env!("COMPILE_TIME_TARGET_CPU");
+
+    if cttc.is_empty() { None } else { Some(cttc) }
+};
+
+pub struct BuildEnv {
+    host: &'static str,
+    target: &'static str,
+    target_cpu: Option<&'static str>,
+}
+
+impl BuildEnv {
+    #[expect(unused, reason = "Library code")]
+    pub fn get_host(&self) -> &'static str {
+        self.host
+    }
+
+    pub fn get_target(&self) -> &'static str {
+        self.target
+    }
+
+    pub fn get_target_cpu(&self) -> Option<&str> {
+        self.target_cpu
+    }
+}
+
+pub fn get_build_env() -> BuildEnv {
+    BuildEnv {
+        host: COMPILE_TIME_HOST,
+        target: COMPILE_TIME_TARGET,
+        target_cpu: COMPILE_TIME_TARGET_CPU,
+    }
+}
+
+impl std::fmt::Display for BuildEnv {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Built on `{}`, targeting `{}`", self.host, self.target)?;
+
+        if let Some(target_cpu) = self.target_cpu {
+            write!(f, " (target-cpu `{}`)", target_cpu)?;
+        }
+
+        Ok(())
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,11 +1,30 @@
+mod build_env;
+
 use base64::Engine as _;
 use base64::engine::general_purpose;
 use color_eyre::config::HookBuilder;
 use color_eyre::eyre;
 use color_eyre::eyre::Report;
 
+use crate::build_env::get_build_env;
+
 #[global_allocator]
 static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
+fn print_header() {
+    const NAME: &str = env!("CARGO_PKG_NAME");
+    const VERSION: &str = env!("CARGO_PKG_VERSION");
+
+    let build_env = get_build_env();
+
+    println!(
+        "{} v{} - built for {} ({})",
+        NAME,
+        VERSION,
+        build_env.get_target(),
+        build_env.get_target_cpu().unwrap_or("base cpu variant"),
+    );
+}
 
 fn main() -> Result<(), eyre::Report> {
     HookBuilder::default()
@@ -13,20 +32,7 @@ fn main() -> Result<(), eyre::Report> {
         .display_env_section(false)
         .install()?;
 
-    let name = env!("CARGO_PKG_NAME");
-    let version = env!("CARGO_PKG_VERSION");
-
-    println!(
-        "{} v{} - built for {}-{}",
-        name,
-        version,
-        std::env::var("TARGETARCH")
-            .as_deref()
-            .unwrap_or("unknown-arch"),
-        std::env::var("TARGETVARIANT")
-            .as_deref()
-            .unwrap_or("base variant")
-    );
+    print_header();
 
     let argument = if let Some(arg) = std::env::args().nth(1) {
         arg


### PR DESCRIPTION
- **fix: regenerate launch.json**
- **fix: regenerate launch.json**
- **chore(deps): update node.js to v24.11.0**
- **chore(deps): update pnpm to v10.20.0**
- **feat: buildscript to embed targetted platform**
- **chore(deps): update enricomi/publish-unit-test-result-action action to v2.21.0**
- **chore(deps): update returntocorp/semgrep docker tag to v1.141.1**
- **chore(deps): update github/codeql-action action to v4.31.1**
- **fix: string_to_string is deprecated and fails in 1.91.0**
- **chore(deps): update github/codeql-action action to v4.31.2**
- **chore: update lints, keep the ones we allow to allow for tracking new ones**
- **chore: update lints**
- **fix: update build_env**
