### PR TITLE
update from upstream

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -594,7 +594,7 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
 
       - name: Upload artifact
-        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         if: |
           matrix.runs-on == 'ubuntu-latest'
         with:
@@ -661,7 +661,7 @@ jobs:
             type=ref,event=pr,suffix=-latest
 
       - name: Download artifacts
-        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         id: artifact
         with:
           merge-multiple: true

--- a/renovate.json
+++ b/renovate.json
@@ -2,6 +2,7 @@
     "$schema": "https://docs.renovatebot.com/renovate-schema.json",
     "extends": [
         "github>kristof-mattei/renovate-config",
+        "github>kristof-mattei/renovate-config//github-actions/nonSemver",
         "github>kristof-mattei/renovate-config//rust/updateRustVersionInCargoToml",
         "github>kristof-mattei/renovate-config//rust/updateChannelInRustToolchainToml"
     ]


### PR DESCRIPTION
- **chore(deps): update github/codeql-action action to v4.31.8**
- **chore(deps): update actions/cache action to v5.0.1**
- **chore(deps): update github artifact actions**
- **chore: write in full semver**
- **chore(deps): update returntocorp/semgrep docker tag to v1.145.2**
- **chore: add exception for non-semver github actions, allowing full-semver all, and non-semver for packages like `mold`**
