### PR TITLE
update from upstream

### DIFF
--- a/.github/scripts/cleanup-containers.sh
+++ b/.github/scripts/cleanup-containers.sh
@@ -11,6 +11,7 @@ dry_run=false
 skip_confirmation=false
 cleanup_pr_images=true
 pr_image_age_days=30
+untagged_grace_days=1
 
 # Parse command line arguments
 while [[ $# -gt 0 ]]; do
@@ -51,16 +52,21 @@ while [[ $# -gt 0 ]]; do
             pr_image_age_days="$2"
             shift 2
             ;;
+        --untagged-grace-days)
+            untagged_grace_days="$2"
+            shift 2
+            ;;
         --help)
-            echo "Usage: $0 [--org ORG | --user USER] [--package PACKAGE_NAME] [--dry-run] [--yes] [--skip-pr-cleanup] [--pr-age-days DAYS] [--help]"
-            echo "  --org              GitHub organization name"
-            echo "  --user             GitHub username"
-            echo "  --package          Package name (default: $package_name)"
-            echo "  --dry-run          Show what would be deleted without actually deleting"
-            echo "  --yes              Skip confirmation prompt"
-            echo "  --skip-pr-cleanup  Skip cleanup of old PR images"
-            echo "  --pr-age-days      Age in days for PR images to be considered old (default: $pr_image_age_days)"
-            echo "  --help             Show this help message"
+            echo "Usage: $0 [--org ORG | --user USER] [--package PACKAGE_NAME] [--dry-run] [--yes] [--skip-pr-cleanup] [--pr-age-days DAYS] [--untagged-grace-days DAYS] [--help]"
+            echo "  --org                   GitHub organization name"
+            echo "  --user                  GitHub username"
+            echo "  --package               Package name (default: $package_name)"
+            echo "  --dry-run               Show what would be deleted without actually deleting"
+            echo "  --yes                   Skip confirmation prompt"
+            echo "  --skip-pr-cleanup       Skip cleanup of old PR images"
+            echo "  --pr-age-days           Age in days for PR images to be considered old (default: $pr_image_age_days)"
+            echo "  --untagged-grace-days   Age in days before untagged versions are deleted (default: $untagged_grace_days)"
+            echo "  --help                  Show this help message"
             echo ""
             echo "Note: --org and --user are mutually exclusive. One must be specified."
             echo "Note: Images with the 'edge' or 'latest' tag will never be deleted."
@@ -355,8 +361,14 @@ for version_id in "${all_version_ids[@]}"; do
     fi
 
     # Check for untagged versions
+    # A concurrent push uploads child manifests before the tagged index, so
+    # recent untagged versions may belong to an image that is still being pushed
     if echo "$tags" | jq --exit-status '. == []' > /dev/null 2>&1; then
-        delete_candidates["$version_id"]="untagged"
+        if is_older_than_days "$created_at" "$untagged_grace_days"; then
+            delete_candidates["$version_id"]="untagged"
+        else
+            protected_versions["$version_id"]="untagged, younger than $untagged_grace_days day(s)"
+        fi
         continue
     fi
 

--- a/.github/workflows/retag-containers-after-push.yml
+++ b/.github/workflows/retag-containers-after-push.yml
@@ -151,7 +151,13 @@ jobs:
             # so we find the last commit that github processed before this one
             # which will have gone through the same retagging process
             # and use that sha as our key to find the Docker container related to that commit
-            old_tag=$(echo "${all_tags}" | grep "^sha-${{ env.BASE_SHA }}-.*\$") # .* is actual or retag
+            old_tag=$(echo "${all_tags}" | grep "^sha-${{ env.BASE_SHA }}-.*\$") || true # .* is actual or retag
+
+            if [ -z "${old_tag}" ]
+            then
+              echo "::error::No matching source tag found for base SHA ${{ env.BASE_SHA }}"
+              exit 1
+            fi
 
             echo "OLD_TAG=${old_tag}" >> "${GITHUB_ENV}"
             echo "SUFFIX=retag" >> "${GITHUB_ENV}"

--- a/.github/workflows/retag-containers-after-release.yml
+++ b/.github/workflows/retag-containers-after-release.yml
@@ -93,24 +93,24 @@ jobs:
           # the source tag is pushed by the push-triggered retag workflow, which may still be running, so poll
           OLD_TAG=""
 
-          for attempt in $(seq 1 30)
-          do
+          for attempt in $(seq 1 30); do
+            if ((attempt > 1)); then
+              sleep 30
+            fi
+
+            echo "Looking for source tag sha-${{ github.sha }}-* (attempt ${attempt} of 30)"
+
             # || true: no match yet, or a transient api error, both mean retry
             OLD_TAG=$(gh api "/users/${{ github.repository_owner }}/packages/container/${repo_lower##*/}/versions" \
               --paginate \
               --jq '.[] | .metadata.container.tags[]' | grep "^sha-${{ github.sha }}-.*\$" | head --lines 1) || true # .* is actual or retag
 
-            if [ -n "${OLD_TAG}" ]
-            then
+            if [ -n "${OLD_TAG}" ]; then
               break
             fi
-
-            echo "No source tag for SHA ${{ github.sha }} yet (attempt ${attempt}/30), retrying in 30 seconds"
-            sleep 30
           done
 
-          if [ -z "${OLD_TAG}" ]
-          then
+          if [ -z "${OLD_TAG}" ]; then
             echo "::error::No matching source tag found for SHA ${{ github.sha }}"
             exit 1
           fi
@@ -164,6 +164,11 @@ jobs:
         run: |
           echo "${{ steps.meta-dockerhub.outputs.tags }}" | while IFS= read -r new_tag
             do
+              if [ "$(skopeo inspect --format '{{ .Digest }}' --no-tags "docker://${new_tag}" 2>/dev/null)" = "${{ steps.digest.outputs.digest }}" ]; then
+                echo "${new_tag} already exists, skipping"
+                continue
+              fi
+
               skopeo copy --all --preserve-digests --command-timeout 70s --retry-times 5 "docker://${FULL_IMAGE_NAME}:${OLD_TAG}" "docker://${new_tag}"
           done
 

--- a/.github/workflows/retag-containers-after-release.yml
+++ b/.github/workflows/retag-containers-after-release.yml
@@ -90,11 +90,27 @@ jobs:
           repo="${{ github.repository }}"
           repo_lower="${repo,,}"
 
-          OLD_TAG=$(gh api "/users/${{ github.repository_owner }}/packages/container/${repo_lower##*/}/versions" \
-            --paginate \
-            --jq '.[] | .metadata.container.tags[]' | grep "^sha-${{ github.sha }}-.*\$" | head --lines 1) # .* is actual or retag
+          # the source tag is pushed by the push-triggered retag workflow, which may still be running, so poll
+          OLD_TAG=""
 
-          if [ -z "${OLD_TAG}" ]; then
+          for attempt in $(seq 1 30)
+          do
+            # || true: no match yet, or a transient api error, both mean retry
+            OLD_TAG=$(gh api "/users/${{ github.repository_owner }}/packages/container/${repo_lower##*/}/versions" \
+              --paginate \
+              --jq '.[] | .metadata.container.tags[]' | grep "^sha-${{ github.sha }}-.*\$" | head --lines 1) || true # .* is actual or retag
+
+            if [ -n "${OLD_TAG}" ]
+            then
+              break
+            fi
+
+            echo "No source tag for SHA ${{ github.sha }} yet (attempt ${attempt}/30), retrying in 30 seconds"
+            sleep 30
+          done
+
+          if [ -z "${OLD_TAG}" ]
+          then
             echo "::error::No matching source tag found for SHA ${{ github.sha }}"
             exit 1
           fi


### PR DESCRIPTION
- **fix(ci): poll for the release source tag instead of racing the push retag**
- **fix(ci): skip Docker Hub tags that already exist with the expected digest**
- **fix(ci): give untagged container versions a grace period before cleanup**
